### PR TITLE
New mouse actions

### DIFF
--- a/src/menus/gameplaymenu.cpp
+++ b/src/menus/gameplaymenu.cpp
@@ -668,7 +668,34 @@ bool GameplayMenu::handleMouseDown(int x, int y, int button, const int modKeys)
     if (paused_)
         return true;
 
-    if (x < 129) {
+    if (button == kMouseMiddleButton) {
+        // Tell the selected agents to panic
+        for (uint8 i = 0; i < AgentManager::kMaxSlot; ++i) {
+            if (selection_.isAgentSelected(i)) {
+                setIPAForAgent(i, IPAStim::Adrenaline, 100);    
+                setIPAForAgent(i, IPAStim::Perception, 100);
+                setIPAForAgent(i, IPAStim::Intelligence, 100);
+            }
+        }
+    } else if (button == kMouseScrollWheelUp) {
+        // Increase IPA levels of the selected agents by 10%
+        for (uint8 i = 0; i < AgentManager::kMaxSlot; ++i) {
+            if (selection_.isAgentSelected(i)) {
+                setIPAForAgent(i, IPAStim::Adrenaline, std::min(mission_->ped(i)->adrenaline_->getAmount()+10, 100));
+                setIPAForAgent(i, IPAStim::Perception, std::min(mission_->ped(i)->perception_->getAmount()+10, 100));
+                setIPAForAgent(i, IPAStim::Intelligence, std::min(mission_->ped(i)->intelligence_->getAmount()+10, 100));
+            }
+        }
+    } else if (button == kMouseScrollWheelDown) {
+        // Decrease IPA levels of the selected agents by 10%
+        for (uint8 i = 0; i < AgentManager::kMaxSlot; ++i) {
+            if (selection_.isAgentSelected(i)) {
+                setIPAForAgent(i, IPAStim::Adrenaline, std::max(mission_->ped(i)->adrenaline_->getAmount()-10, 0));
+                setIPAForAgent(i, IPAStim::Perception, std::max(mission_->ped(i)->perception_->getAmount()-10, 0));
+                setIPAForAgent(i, IPAStim::Intelligence, std::max(mission_->ped(i)->intelligence_->getAmount()-10, 0));
+            }
+        }
+    } else if (x < 129) {
         bool ctrl = false;  // Is control button pressed
         if (modKeys & KMD_CTRL) {
             ctrl = true;

--- a/src/menus/menu.cpp
+++ b/src/menus/menu.cpp
@@ -38,6 +38,9 @@ const int Menu::MENU_NO_MENU = -1;
 const int Menu::kMenuIdLogout = 6;
 const int Menu::kMouseLeftButton = 1;
 const int Menu::kMouseRightButton = 3;
+const int Menu::kMouseMiddleButton = 2;
+const int Menu::kMouseScrollWheelUp = 4;
+const int Menu::kMouseScrollWheelDown = 5;
 
 Menu::Menu(MenuManager * menuManager, int id, int parentId, 
     const char *showAnim, const char *leaveAnim) :

--- a/src/menus/menu.h
+++ b/src/menus/menu.h
@@ -50,6 +50,12 @@ public:
     static const int kMouseLeftButton;
     /*! Id of the mouse right button.*/
     static const int kMouseRightButton;
+    /*! Id of the mouse middle button.*/
+    static const int kMouseMiddleButton;
+    /*! Id of the mouse scroll wheel up.*/
+    static const int kMouseScrollWheelUp;
+    /*! Id of the mouse scroll wheel down.*/
+    static const int kMouseScrollWheelDown;
 
     /*!
         * Menu constructor.


### PR DESCRIPTION
Hi, @winterheart 

In the original game pressing left and right mouse simultaneously made all selected agents to "panic" (their IPA levels got increased to max). FreeSynd doesn't have such hotkey. This pull request assigns the middle button to the panic action. Moreover, it also makes IPA levels controlled by scrolling mouse wheel up and down:
- Middle click makes the selected agents to panic (all IPA levels at max);
- Mouse wheel scroll up increases all IPA levels of the selected agents by 10%;
- Mouse wheel scroll down decreases all IPA levels of the selected agents by 10%.

Cheers.